### PR TITLE
Feature: Update release filenames in CI script

### DIFF
--- a/.github/workflows/pi4j-os.yml
+++ b/.github/workflows/pi4j-os.yml
@@ -52,6 +52,6 @@ jobs:
           RELEASE_VERSION: ${{ steps.env.outputs.RELEASE_VERSION }}
         run: |
           sshpass -e sftp -oBatchMode=no -oStrictHostKeyChecking=no -b - "${SFTP_USERNAME}@${SFTP_SERVER}" << EOS
-          put crowpi/crowpi.img.zip "${RELEASE_VERSION}-crowpi.img.zip"
-          put crowpi/crowpi.img.sha256 "${RELEASE_VERSION}-crowpi.img.sha256"
+          put crowpi/crowpi.img.zip "crowpi-${RELEASE_VERSION}.img.zip"
+          put crowpi/crowpi.img.sha256 "crowpi-${RELEASE_VERSION}.img.sha256"
           EOS


### PR DESCRIPTION
This change slightly adjusts the CI workflow to name the file `<flavor>-<version>.img.zip` and `<flavor>-<version>.img.sha256` respectively instead of `<version>-<flavor>`. Example:

- **Before:** `main-crowpi.img.zip`, `1.0.0-crowpi.img.zip`, ...
- **After:** `crowpi-main.img.zip`, `crowpi-1.0.0.img.zip`, ...

This will make it easier to distinguish the file, especially once the Picade flavor is available too. The [version script](https://pi4j-download.com/versions.php) on pi4j-download.com has already been updated accordingly and I adjusted the name of the existing image to match this as well.