### PR TITLE
Automated readme update of Pi4J/download on release

### DIFF
--- a/.github/workflows/pi4j-os.yml
+++ b/.github/workflows/pi4j-os.yml
@@ -61,3 +61,22 @@ jobs:
           put "${{ matrix.flavor }}.img.zip" "${{ matrix.flavor }}-${RELEASE_VERSION}.img.zip"
           put "${{ matrix.flavor }}.img.sha256" "${{ matrix.flavor }}-${RELEASE_VERSION}.img.sha256"
           EOS
+
+  update-download-readme:
+    runs-on: ubuntu-20.04
+    if: >-
+      github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    needs:
+      - main
+    steps:
+      - name: Trigger dynamic README update of Pi4J/download
+        env:
+          GITHUB_PAT: ${{ secrets.PI4J_BOT_GITHUB_PAT }}
+        run: >-
+          curl
+          --silent --show-error --fail --fail
+          -X POST
+          -H "Accept: application/vnd.github.v3+json"
+          -H "Authorization: Token ${GITHUB_PAT}"
+          https://api.github.com/repos/pi4j/download/actions/workflows/dynamic-readme.yml/dispatches
+          -d '{"ref":"refs/heads/main"}'


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to automatically trigger an update of the dynamic README stored at https://github.com/Pi4J/download. To do so, the newly created [Pi4J bot account](https://github.com/pi4j-bot) is being used for dispatching a workflow in the target repository.

The repository secret `PI4J_BOT_GITHUB_PAT` has been added to store the Personal Access Token for this bot account.