### PR TITLE
Feature: Switch image architecture to aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@
 /build.pwd
 /build.pwi
 
+# Java
+.classpath
+.project
+.settings/
+
 # Development
+/.vscode/
 /.idea/
 /local/

--- a/README.adoc
+++ b/README.adoc
@@ -8,8 +8,7 @@ This project provides pre-built versions of custom OS images with all you need t
 * preconfigured locale (en_US), keyboard (US) and timezone (Europe/Zurich)
 * preconfigured wireless country (Switzerland) by default
 * remote management via `SSH` and `VNC` enabled by default
-* preinstalled https://openjdk.java.net[OpenJDK 11] with latest https://openjfx.io[JavaFX]
-** currently `JavaFX-17.0.0.1`
+* preinstalled https://openjdk.java.net[OpenJDK 17] with latest https://gluonhq.com/products/javafx/[Gluon JavaFX 17]
 * starter script to launch JavaFX-apps in DRM (aka kiosk-mode)
 * preconfigured `/boot/config.txt` supporting all components out of the box
 * dynamic wallpaper that shows Ethernet/WLAN address and hostname

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ This project provides pre-built versions of custom OS images with all you need t
 * default WLAN connection
 ** setup a hotspot, for example on your smartphone, and you are ready to go.
 *** ssid: `Pi4J-Spot`
-*** password: `MayTheCodeBeWithYou!`
+*** password: `MayTheSourceBeWithYou!`
 ** your laptop has to be in the same WLAN as the RaspPi
 
 The zip-compressed archives can be downloaded from https://pi4j-download.com[pi4j-download.com].

--- a/base/base.sh
+++ b/base/base.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -euxo pipefail
 
 # Script configuration
 declare -gr GLUON_JAVAFX_VERSION="17.0.1"

--- a/base/base.sh
+++ b/base/base.sh
@@ -92,7 +92,7 @@ sudo install -Dm 0755 /tmp/res-base/java/java-kiosk.py /usr/local/bin/java-kiosk
 sudo install -Dm 0755 /tmp/res-base/java/java-last-kiosk.py /usr/local/bin/java-last-kiosk
 
 # Compile and deploy helper executable for detecting primary video card
-gcc -I/usr/include/libdrm -ldrm -o /usr/local/bin/detect-primary-card /tmp/res-base/system/detect-primary-card.c
+gcc -I/usr/include/libdrm -o /usr/local/bin/detect-primary-card /tmp/res-base/system/detect-primary-card.c -ldrm
 
 # Deploy music samples
 sudo -u pi install -Dm 0644 /tmp/res-base/music/* -t /home/pi/Music/

--- a/base/base.sh
+++ b/base/base.sh
@@ -39,7 +39,7 @@ apt-get -qqy install \
   libdrm-dev \
   lirc \
   maven \
-  openjdk-11-jdk
+  openjdk-17-jdk
 rm -rf /var/lib/apt/lists/*
 
 # Download and extract Gluon JavaFX

--- a/base/base.sh
+++ b/base/base.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 # Script configuration
 declare -gr GLUON_JAVAFX_VERSION="17.0.1"
-declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_linux-aarch64_bin-sdk.zip"
+declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_monocle_linux-aarch64_bin-sdk.zip"
 declare -gr GLUON_JAVAFX_PATH="/opt/javafx-sdk"
 declare -gr GLUON_JAVAFX_VERSION_PATH="/opt/javafx-sdk-${GLUON_JAVAFX_VERSION}"
 

--- a/base/base.sh
+++ b/base/base.sh
@@ -2,8 +2,8 @@
 set -x
 
 # Script configuration
-declare -gr GLUON_JAVAFX_VERSION="17.0.0.1"
-declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_linux-arm32_bin-sdk.zip"
+declare -gr GLUON_JAVAFX_VERSION="17.0.1"
+declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_linux-aarch64_bin-sdk.zip"
 declare -gr GLUON_JAVAFX_PATH="/opt/javafx-sdk"
 declare -gr GLUON_JAVAFX_VERSION_PATH="/opt/javafx-sdk-${GLUON_JAVAFX_VERSION}"
 

--- a/base/base.sh
+++ b/base/base.sh
@@ -32,7 +32,7 @@ done
 # Install and upgrade software packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
-apt-get -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' upgrade --fix-broken
+apt-get -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' dist-upgrade
 apt-get -y install \
   git \
   imagemagick \

--- a/base/base.sh
+++ b/base/base.sh
@@ -31,9 +31,9 @@ done
 
 # Install and upgrade software packages
 export DEBIAN_FRONTEND=noninteractive
-apt-get -qqy update
-apt-get -qqy -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' upgrade
-apt-get -qqy install \
+apt-get -y update
+apt-get -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' upgrade
+apt-get -y install \
   git \
   imagemagick \
   libdrm-dev \

--- a/base/base.sh
+++ b/base/base.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 # Script configuration
 declare -gr GLUON_JAVAFX_VERSION="17.0.1"
-declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_monocle_linux-aarch64_bin-sdk.zip"
+declare -gr GLUON_JAVAFX_URL="https://download2.gluonhq.com/openjfx/${GLUON_JAVAFX_VERSION}/openjfx-${GLUON_JAVAFX_VERSION}_monocle-linux-aarch64_bin-sdk.zip"
 declare -gr GLUON_JAVAFX_PATH="/opt/javafx-sdk"
 declare -gr GLUON_JAVAFX_VERSION_PATH="/opt/javafx-sdk-${GLUON_JAVAFX_VERSION}"
 

--- a/base/base.sh
+++ b/base/base.sh
@@ -32,7 +32,7 @@ done
 # Install and upgrade software packages
 export DEBIAN_FRONTEND=noninteractive
 apt-get -y update
-apt-get -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' upgrade
+apt-get -y -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' upgrade --fix-broken
 apt-get -y install \
   git \
   imagemagick \

--- a/base/resources/java-deploy/pom.xml
+++ b/base/resources/java-deploy/pom.xml
@@ -11,7 +11,7 @@
 
     <!-- BUILD PROPERTIES -->
     <properties>
-        <pi4j.version>2.0</pi4j.version>
+        <pi4j.version>2.1.0</pi4j.version>
 
         <slf4j.version>1.7.32</slf4j.version>
 

--- a/base/resources/java-deploy/pom.xml
+++ b/base/resources/java-deploy/pom.xml
@@ -16,7 +16,7 @@
         <slf4j.version>1.7.32</slf4j.version>
 
         <!-- Maven Plugin Versions -->
-        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
     </properties>
 
     <!-- DEPENDENCY REPOSITORIES -->

--- a/base/resources/java-examples/pure-javafx/hellofx/HelloFX.java
+++ b/base/resources/java-examples/pure-javafx/hellofx/HelloFX.java
@@ -8,9 +8,10 @@ import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
-//import javafx.scene.media.AudioClip;
-//import javafx.scene.media.Media;
-//import javafx.scene.media.MediaPlayer;
+import javafx.scene.media.AudioClip;
+import javafx.scene.media.Media;
+import javafx.scene.media.MediaPlayer;
+import javafx.scene.media.MediaView;
 import javafx.stage.Stage;
 
 /**
@@ -18,11 +19,10 @@ import javafx.stage.Stage;
  *
  * It's a long way from here to a real application.
  *
- * But as long as 'HelloFX' isn't working properly, it's useless to go any further.
- *
  * It's not meant to be any kind of template to start your development.
  *
- * Initially copied from https://github.com/openjfx/samples/blob/master/CommandLine/Modular/CLI/hellofx/src/hellofx/HelloFX.java
+ * Initially copied from
+ * https://github.com/openjfx/samples/blob/master/CommandLine/Modular/CLI/hellofx/src/hellofx/HelloFX.java
  *
  * @author Dieter Holz
  */
@@ -30,27 +30,28 @@ public class HelloFX extends Application {
 
     @Override
     public void start(Stage stage) {
-        String javaVersion   = System.getProperty("java.version");
+        String javaVersion = System.getProperty("java.version");
         String javafxVersion = System.getProperty("javafx.version");
 
-//        MediaPlayer mediaPlayer = new MediaPlayer(new Media(getClass().getResource("bgm.mp3").toExternalForm()));
-//        mediaPlayer.setCycleCount(MediaPlayer.INDEFINITE);
-//        mediaPlayer.play();
+        MediaPlayer mediaPlayer = new MediaPlayer(new Media(getClass().getResource("bgm.mp3").toExternalForm()));
+        mediaPlayer.setCycleCount(MediaPlayer.INDEFINITE);
+        mediaPlayer.setAutoPlay(true);
+        MediaView mediaView = new MediaView(mediaPlayer);
 
         Label lbl = new Label("JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
 
-//        AudioClip dropSound = new AudioClip(getClass().getResource("drop.wav").toExternalForm());
+        AudioClip dropSound = new AudioClip(getClass().getResource("drop.wav").toExternalForm());
         Button btn = new Button("Say Hello");
         btn.setOnAction(event -> {
             lbl.setText("Hello");
-//            dropSound.play();
+            dropSound.play();
         });
 
         ImageView imgView = new ImageView(new Image(HelloFX.class.getResourceAsStream("openduke.png")));
         imgView.setFitHeight(200);
         imgView.setPreserveRatio(true);
 
-        VBox rootPane = new VBox(50, imgView, lbl, btn);
+        VBox rootPane = new VBox(50, mediaView, imgView, lbl, btn);
         rootPane.setAlignment(Pos.CENTER);
 
         rootPane.getStylesheets().add(HelloFX.class.getResource("styles.css").toExternalForm());

--- a/base/resources/system/wpa-supplicant.conf
+++ b/base/resources/system/wpa-supplicant.conf
@@ -4,5 +4,5 @@ country=CH
 
 network={
     ssid="Pi4J-Spot"
-    psk="MayTheCodeBeWithYou!"
+    psk="MayTheSourceBeWithYou!"
 }

--- a/base/resources/wallpaper/wallpaper-systemd.service
+++ b/base/resources/wallpaper/wallpaper-systemd.service
@@ -4,4 +4,5 @@ Description=Update FHNW wallpaper
 [Service]
 Type=oneshot
 ExecStartPre=/usr/bin/timeout 5 /bin/bash -c 'while ! pgrep --count -xf "pcmanfm --desktop --profile LXDE-pi" &>/dev/null; do sleep 0.5; done'
+ExecStartPre=/usr/bin/timeout 5 /bin/bash -c 'while ! test -S "${XDG_RUNTIME_DIR}/pcmanfm-socket-$(echo "${DISPLAY}" | cut -d':' -sf1)-$(echo "${DISPLAY}" | cut -d':' -sf2)"; do sleep 0.5; done'
 ExecStart=/usr/bin/pcmanfm --set-wallpaper=/opt/fhnw/wallpaper-dynamic.jpg --wallpaper-mode=stretch

--- a/crowpi.pkr.hcl
+++ b/crowpi.pkr.hcl
@@ -1,9 +1,9 @@
 source "arm" "raspios" {
   # Raspberry Pi OS with Desktop
   file_urls = [
-    "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-05-28/2021-05-07-raspios-buster-armhf.zip"
+    "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip"
   ]
-  file_checksum_url = "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-05-28/2021-05-07-raspios-buster-armhf.zip.sha256"
+  file_checksum_url = "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip.sha256"
   file_checksum_type = "sha256"
   file_target_extension = "zip"
 
@@ -34,8 +34,8 @@ source "arm" "raspios" {
   }
 
   # QEMU Toolchain
-  qemu_binary_source_path = "/usr/bin/qemu-arm-static"
-  qemu_binary_destination_path = "/usr/bin/qemu-arm-static"
+  qemu_binary_source_path = "/usr/bin/qemu-aarch64-static"
+  qemu_binary_destination_path = "/usr/bin/qemu-aarch64-static"
 }
 
 build {

--- a/picade.pkr.hcl
+++ b/picade.pkr.hcl
@@ -1,9 +1,9 @@
 source "arm" "raspios" {
   # Raspberry Pi OS with Desktop
   file_urls = [
-    "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-05-28/2021-05-07-raspios-buster-armhf.zip"
+    "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip"
   ]
-  file_checksum_url = "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-05-28/2021-05-07-raspios-buster-armhf.zip.sha256"
+  file_checksum_url = "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip.sha256"
   file_checksum_type = "sha256"
   file_target_extension = "zip"
 


### PR DESCRIPTION
This PR changes the default image architecture from armhf (32-bit) to aarch64 (64-bit) for both CrowPi and Picade. This is the modern approach for Raspberry Pi devices and could potentially resolve some outstanding issues with Gluon X11/DRM.