### PR TITLE
Fix: Ensure sanitized build version contains dots

### DIFF
--- a/.github/workflows/pi4j-os.yml
+++ b/.github/workflows/pi4j-os.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Prepare build environment
         id: env
         run: |
-          echo ::set-output name=RELEASE_VERSION::$(echo "${GITHUB_REF#refs/*/}" | sed 's/\//-/g' | tr -cd '[:alnum:]-')
+          echo ::set-output name=RELEASE_VERSION::$(echo "${GITHUB_REF#refs/*/}" | sed 's/\//-/g' | tr -cd '[0-9a-zA-Z.]-')
 
       - name: Build OS image with Packer
         id: build


### PR DESCRIPTION
This PR adjusts the regular expression used for sanitizing the build version to allow dots, so that the resulting images are stored as `0.1.0` instead of `010` as done with the previous Git tag. The existing images have been manually renamed to be in accordance with upcoming images after this PR.

Will merge this myself in a couple minutes when CI passed due to no serious impact.