### PR TITLE
Feature: Install `zip` as part of every image

### DIFF
--- a/base/base.sh
+++ b/base/base.sh
@@ -39,7 +39,8 @@ apt-get -y install \
   libdrm-dev \
   lirc \
   maven \
-  openjdk-17-jdk
+  openjdk-17-jdk \
+  zip
 rm -rf /var/lib/apt/lists/*
 
 # Download and extract Gluon JavaFX


### PR DESCRIPTION
This PR closes #31 by installing the `zip` utility as part of all our available images. This will provide both `zip` and `unzip` as available commands for the users.