### PR TITLE
Add Java headless setup script with error handling and dependencies

### DIFF
--- a/script/prepare-for-java-headless.sh
+++ b/script/prepare-for-java-headless.sh
@@ -61,7 +61,7 @@ echo "   "
 
 echo "STEP: Install missing dependencies"
 echo "   "
-sudo apt install --no-install-recommends --no-install-suggests -y i2c-tools vim git java-common libxi6 libxrender1 libxtst6
+sudo apt install -y i2c-tools vim git java-common libxi6 libxrender1 libxtst6 fontconfig-config  fonts-freefont-ttf  libfontconfig1  libfreetype6 || die
 
 echo "   "
 echo "-------------------------"

--- a/script/prepare-for-java-headless.sh
+++ b/script/prepare-for-java-headless.sh
@@ -32,11 +32,36 @@ echo "   "
 echo "-------------------------"
 echo "   "
 
+# Configuration changes
+
+echo "STEP: Enable SSH and VNC"
+echo "   "
+sudo raspi-config nonint do_ssh 0
+
+echo "   "
+echo "-------------------------"
+echo "   "
+
+echo "STEP: Apply configuration changes to easier interact with electronic components"
+echo "   "
+sudo raspi-config nonint do_i2c 0
+sudo raspi-config nonint do_spi 0
+sudo raspi-config nonint do_serial_hw 0
+sudo raspi-config nonint do_serial_cons 1
+sudo raspi-config nonint do_onewire 0
+sudo sed -i "$ a\dtoverlay=pwm-2chan" /boot/firmware/config.txt
+sudo systemctl disable hciuart
+sudo echo "dtoverlay=disable-bt" | tee -a /boot/firmware/config.txt
+
+echo "   "
+echo "-------------------------"
+echo "   "
+
 # Missing dependencies
 
 echo "STEP: Install missing dependencies"
 echo "   "
-sudo apt install -y i2c-tools vim git java-common libxi6 libxrender1 libxtst6
+sudo apt install --no-install-recommends --no-install-suggests -y i2c-tools vim git java-common libxi6 libxrender1 libxtst6
 
 echo "   "
 echo "-------------------------"
@@ -50,11 +75,20 @@ echo "   "
 echo "-------------------------"
 echo "   "
 
+# Install Java (SDK with JavaFX) and related tools
+
+echo "STEP: Install Java"
+echo "   "
+wget https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
+sudo dpkg -i zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
+rm zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
+echo "   "
+echo "Installed Java version:"
+java -version
+
 echo "   "
 echo "-------------------------"
 echo "   "
-
-# Install SDKMAN and use it to install Java (SDK with JavaFX) and related tools
 
 echo "STEP: Install SDKMAN"
 echo "   "
@@ -62,17 +96,6 @@ curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 echo "Installed SDKMAN version:"
 sdk version
-
-echo "   "
-echo "-------------------------"
-echo "   "
-
-echo "STEP: Install Java"
-echo "   "
-sdk install java 25.fx-zulu
-echo "   "
-echo "Installed Java version:"
-java -version
 
 echo "   "
 echo "-------------------------"

--- a/script/prepare-for-java-headless.sh
+++ b/script/prepare-for-java-headless.sh
@@ -18,7 +18,7 @@ echo "   "
 # System updates
 echo "STEP: Update the list of available packages and their versions"
 echo "   "
-sudo apt update
+sudo apt update || die
 
 echo "   "
 echo "-------------------------"
@@ -26,7 +26,7 @@ echo "   "
 
 echo "STEP: Install the newest versions of all currently installed packages that have available updates"
 echo "   "
-sudo apt upgrade -y
+sudo apt upgrade -y || die
 
 echo "   "
 echo "-------------------------"
@@ -36,7 +36,7 @@ echo "   "
 
 echo "STEP: Enable SSH and VNC"
 echo "   "
-sudo raspi-config nonint do_ssh 0
+sudo raspi-config nonint do_ssh 0 || die
 
 echo "   "
 echo "-------------------------"
@@ -44,12 +44,12 @@ echo "   "
 
 echo "STEP: Apply configuration changes to easier interact with electronic components"
 echo "   "
-sudo raspi-config nonint do_i2c 0
-sudo raspi-config nonint do_spi 0
-sudo raspi-config nonint do_serial_hw 0
-sudo raspi-config nonint do_serial_cons 1
-sudo raspi-config nonint do_onewire 0
-sudo sed -i "$ a\dtoverlay=pwm-2chan" /boot/firmware/config.txt
+sudo raspi-config nonint do_i2c 0 || die
+sudo raspi-config nonint do_spi 0 || die
+sudo raspi-config nonint do_serial_hw 0 || die
+sudo raspi-config nonint do_serial_cons 1 || die
+sudo raspi-config nonint do_onewire 0 || die
+sudo sed -i "$ a\dtoverlay=pwm-2chan" /boot/firmware/config.txt || die
 sudo systemctl disable hciuart
 sudo echo "dtoverlay=disable-bt" | tee -a /boot/firmware/config.txt
 
@@ -69,7 +69,7 @@ echo "   "
 
 echo "STEP: I2C dependency needed for FFM plugin"
 echo "   "
-sudo apt install -y libi2c-dev
+sudo apt install -y libi2c-dev || die
 
 echo "   "
 echo "-------------------------"
@@ -79,12 +79,12 @@ echo "   "
 
 echo "STEP: Install Java"
 echo "   "
-wget https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
-sudo dpkg -i zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
-rm zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb
+wget https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb || die
+sudo dpkg -i zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb || die
+rm zulu25.34.17-ca-jdk25.0.3-linux_arm64.deb || die
 echo "   "
 echo "Installed Java version:"
-java -version
+java -version || die
 
 echo "   "
 echo "-------------------------"
@@ -92,10 +92,10 @@ echo "   "
 
 echo "STEP: Install SDKMAN"
 echo "   "
-curl -s "https://get.sdkman.io" | bash
+curl -s "https://get.sdkman.io" | bash || die
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 echo "Installed SDKMAN version:"
-sdk version
+sdk version || die
 
 echo "   "
 echo "-------------------------"
@@ -103,10 +103,10 @@ echo "   "
 
 echo "STEP: Install Maven"
 echo "   "
-sdk install maven
+sdk install maven || die
 echo "   "
 echo "Installed Maven version:"
-mvn -v
+mvn -v || die
 
 echo "   "
 echo "-------------------------"
@@ -114,10 +114,10 @@ echo "   "
 
 echo "STEP: Install JBang"
 echo "   "
-sdk install jbang
+sdk install jbang || die
 echo "   "
 echo "Installed JBang version:"
-jbang --version
+jbang --version || die
 
 echo "   "
 echo "-------------------------"

--- a/script/prepare-for-java.sh
+++ b/script/prepare-for-java.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Ensure the script is running as sudo
+# Ensure the script is *NOT* running as sudo
 if [ "$EUID" -eq 0 ]; then
   echo "   "
   echo "Please do not run this script with sudo!"


### PR DESCRIPTION
This pull request introduces a new script for Java headless setup, providing the following updates:
- Added error handling in the script using `|| die` for critical commands to ensure robust execution.
- Included missing font dependencies to prevent runtime issues.
- Improved comments in existing scripts related to proper `sudo` usage.